### PR TITLE
fix search count on search results page

### DIFF
--- a/shopify/sections/main-search.liquid
+++ b/shopify/sections/main-search.liquid
@@ -35,8 +35,7 @@
   {% paginate search.results by 16 %}
     {% if search.performed %}
       {% if search and search.results != empty %}
-        {% assign amount = search.results | size %}
-        {% render 'layout-sort-bar', amount: amount class: 'mb-8' %}
+        {% render 'layout-sort-bar', amount: search.results_count class: 'mb-8' %}
 
         <div class="grid sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-x-4 gap-y-8">
           {% for product in search.results %}


### PR DESCRIPTION
On the search results page, the results count is based on `search.results.size`. `search.results` is paginated and is maxed at 16. Using `search.results_count` (see: https://shopify.dev/api/liquid/objects/search#search-results_count) fix that issue.