### PR TITLE
Product names could contain single quote char

### DIFF
--- a/shopify/sections/main-product.liquid
+++ b/shopify/sections/main-product.liquid
@@ -119,9 +119,9 @@
           <div class="flex-1">
             <renderless-product-variant-selector
               v-slot="{ selectedVariant, selectOption }"
-              :current-variant="{{ current_variant | json | replace: '"', "'" }}"
-              :product-options="{{ product.options_with_values | json | replace: '"', "'" }}"
-              :product-variants="{{ product.variants | json | replace: '"', "'" }}"
+              :current-variant="{{ current_variant | json | replace: "'", "\\'" | replace: '"', "'" }}"
+              :product-options="{{ product.options_with_values | json | replace: "'", "\\'" | replace: '"', "'" }}"
+              :product-variants="{{ product.variants | json | replace: "'", "\\'" | replace: '"', "'" }}"
             >
               <div>
                 <input


### PR DESCRIPTION
Product names with single quotes throw an "Unexpected Token" error.

I have a product named: 
`ADIDAS | KID'S STAN SMITH`
This single quote breaks the app.

With this PR the single quotes will be replaced by `\'` fixing the issue.