### PR TITLE
Fix for shopify CLI 3.X

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "deploy:new": "run-s webpack:build && cd shopify && shopify theme push --unpublished",
     "webpack:watch": "cross-env NODE_ENV=development BROWSERSLIST_ENV=development BROWSERSLIST_CONFIG=.config/.browserslistrc webpack --config .config/webpack/webpack.dev.js --watch --progress",
     "webpack:build": "cross-env NODE_ENV=production BROWSERSLIST_ENV=production BROWSERSLIST_CONFIG=.config/.browserslistrc webpack --config .config/webpack/webpack.prod.js --progress",
-    "shopify:serve": "cd shopify && shopify theme serve",
+    "shopify:serve": "cd shopify && shopify theme dev",
     "shopify:pull": "cd shopify && shopify theme pull",
     "lint": "run-s -c lint:*",
     "lint:js": "eslint src/**/*.{js,vue} --config .config/.eslintrc.js",


### PR DESCRIPTION
Fix for the command `shopify theme serve` change to `shopify theme dev`

ref: https://shopify.dev/themes/tools/cli/migrate

I'll also update documentation to reflect this.